### PR TITLE
Removed whitespace generated when using templateChooser

### DIFF
--- a/src/reusable/templateChooser.html
+++ b/src/reusable/templateChooser.html
@@ -1,51 +1,39 @@
-{{#if (test this.[@type] (toRegex ".*/text")) }}
+{{#if (test this.[@type] (toRegex ".*/text")) ~}}
 {{> text }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/video")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/video")) ~}}
 {{> video }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/promobanner")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/promobanner")) ~}}
 {{> promoBanner }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/splitblock")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/splitblock")) ~}}
 {{> splitBlock }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/slider")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/slider")) ~}}
 {{> slider }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/image")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/image")) ~}}
 {{> image this}}
-{{/if}}
-
-{{#if (test this.[0].[@type] (toRegex ".*/image")) }}
+{{~/if}}
+{{#if (test this.[0].[@type] (toRegex ".*/image")) ~}}
 {{> image this.[0]}}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/externalblock")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/externalblock")) ~}}
 {{> externalBlock }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/cardlist")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/cardlist")) ~}}
 {{> cardList }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/card.json")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/card.json")) ~}}
 {{> card }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/blog")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/blog")) ~}}
 {{> blog }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/banner")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/banner")) ~}}
 {{> banner }}
-{{/if}}
-
-{{#if (test this.[@type] (toRegex ".*/homepage")) }}
+{{~/if}}
+{{#if (test this.[@type] (toRegex ".*/homepage")) ~}}
 {{> homepage }}
-{{/if}}
+{{~/if}}


### PR DESCRIPTION
Because the templateChooser contains a lot of if statements, if can lead to a lot whitespace being generated.

Added handebars expression to if statements
 - http://handlebarsjs.com/expressions.html#whitespace-control

Removed whitespace between IF statements