### PR TITLE
SFCC slot accelerators

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If using macOS older than Sierra, there is another way to show hidden files:
 
 For Unix-based systems, go to the directory where you want to view hidden files and press `ctrl + h`
     
-## Installation
+## Installation - Standard Accelerators
 
 Note that the installation requires Node version 6.14.3 or higher.
 
@@ -86,6 +86,20 @@ $ npm install --global gulp-cli
 $ gulp
 ```
 Open a page with desired render, e.g. localhost:9100/dist/renders/image/index.html
+
+## Installation - Salesforce Commerce Cloud Accelerators
+
+Salesforce Commerce Cloud (SFCC) accelerators can be installed in addition to the standard accelerators using the following commands:
+
+```bash
+# Install dependencies 
+$ npm install
+$ npm install --global gulp-cli
+
+# Build project
+$ gulp sfcc
+```
+
 ## Demo
 Here you can find the Dynamic Content Inventory, where all the accelerator modules are shown:
 

--- a/dist/contentTypes/link.json
+++ b/dist/contentTypes/link.json
@@ -3,6 +3,11 @@
   "id": "https://s3-eu-west-1.amazonaws.com/dev-solutions/DC-accelerators-with-CRS-v2.0.0/dist/contentTypes/link.json",
   "title": "Link Accelerator",
   "description": "Link Accelerator",
+  "allOf": [
+    {
+      "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
+    }
+  ],
   "propertyOrder": [
     "label",
     "value"

--- a/dist/contentTypes/roundel.json
+++ b/dist/contentTypes/roundel.json
@@ -3,6 +3,11 @@
   "id": "https://s3-eu-west-1.amazonaws.com/dev-solutions/DC-accelerators-with-CRS-v2.0.0/dist/contentTypes/roundel.json",
   "title": "Roundel",
   "description": "Roundel Accelerator",
+  "allOf": [
+    {
+      "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
+    }
+  ],
   "propertyOrder": [
     "roundel",
     "roundelRatio",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,11 +87,22 @@ gulp.task('addContentTypes', ['build'], function (cb) {
 });
 
 gulp.task('sfcc-copy', function () {
-    gulp.src('./src/reusable/slotContentTypes/sfcc-slot-accelerators.json')
+    return gulp.src('./src/reusable/slotContentTypes/sfcc-slot-accelerators.json')
         .pipe(replace())
         .pipe(
             gulp.dest('./dist/contentTypes/')
         );
+});
+
+gulp.task('sfcc-templates-copy', function () {
+    return gulp
+        .src('src/reusable/sfcc-contentWrapper.html')
+        .pipe(
+            rename(function (path) {
+                path.dirname = '';
+            })
+        )
+        .pipe(gulp.dest('dist/templates'));
 });
 
 gulp.task('addPackageStyles', function () {
@@ -408,7 +419,7 @@ gulp.task('buildAll', ['buildAllWithoutReload'], function () {
     return gulp.src('*').pipe(connect.reload());
 });
 
-gulp.task('sfcc', ['buildAllWithoutReload', 'sfcc-copy'], function () {
+gulp.task('sfcc', ['buildAllWithoutReload', 'sfcc-copy', 'sfcc-templates-copy'], function () {
     return gulp.src('*').pipe(connect.reload());
 });
 

--- a/src/reusable/sfcc-contentWrapper.html
+++ b/src/reusable/sfcc-contentWrapper.html
@@ -1,0 +1,3 @@
+{{#if (test this.[@type] (toRegex ".*/sfcc-slot-accelerators.json")) ~}}
+{{> templateChooser this.content }}
+{{~/if}}

--- a/src/reusable/slotContentTypes/sfcc-slot-accelerators.json
+++ b/src/reusable/slotContentTypes/sfcc-slot-accelerators.json
@@ -5,9 +5,9 @@
 			"$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
 		}
 	],
-	"id": "http://dev-tupperware.s3-website-eu-west-1.amazonaws.com/sfccdev/sfcc-slot-full.json",
-	"title": "content-type-slot-example.json",
-	"description": "content-type-slot-example.json description",
+	"id": "{CONTENT_TYPE_BASEPATH}/sfcc-slot-accelerators.json",
+	"title": "SFCC Slot all accelerators",
+	"description": "SFCC Slot all accelerators",
 	"type": "object",
 	"properties": {
 		"_environment": {


### PR DESCRIPTION
This adds accelerators for Salesforce Commerce Cloud (SFCC):

- SFCC slot content type
- Handlebars template
- Updated README